### PR TITLE
Unix timestamp placeholder

### DIFF
--- a/docs/sink-connector-config-options.rst
+++ b/docs/sink-connector-config-options.rst
@@ -43,6 +43,9 @@ Connection
   * Valid Values: Key value pair string list with format header:value
   * Importance: low
 
+  Placeholders
+  * ${unix-timestamp}: Current System Timestamp
+
 ``oauth2.access.token.url``
   The URL to be used for fetching an access token. Client Credentials is the only supported grant type.
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=0.9.0-SNAPSHOT
+version=0.9.1-SNAPSHOT

--- a/src/main/java/io/aiven/kafka/connect/http/sender/AbstractHttpSender.java
+++ b/src/main/java/io/aiven/kafka/connect/http/sender/AbstractHttpSender.java
@@ -103,6 +103,14 @@ abstract class AbstractHttpSender {
         throw new ConnectException("Sending failed and no retries remain, stopping");
     }
 
+    /**
+     * Refreshes the headers in the given HTTP request by replacing placeholders with dynamically generated values.
+     * Specifically, it replaces occurrences of {@code HTTP_HEADER_UNIX_PLACEHOLDER} with the current system timestamp.
+     *
+     * @param request - The original HTTP request to be modified.
+     *
+     * @return A new {@link HttpRequest} instance with updated headers.
+     */
     protected HttpRequest refreshHeaders(final HttpRequest request) {
         // Duplicate the request
         final HttpRequest.Builder newRequestBuilder = HttpRequest.newBuilder(request.uri())

--- a/src/main/java/io/aiven/kafka/connect/http/sender/HttpSender.java
+++ b/src/main/java/io/aiven/kafka/connect/http/sender/HttpSender.java
@@ -17,8 +17,10 @@
 package io.aiven.kafka.connect.http.sender;
 
 import java.net.http.HttpResponse;
-import io.aiven.kafka.connect.http.converter.RecordValueConverter;
+
 import org.apache.kafka.connect.sink.SinkRecord;
+
+import io.aiven.kafka.connect.http.converter.RecordValueConverter;
 
 
 public interface HttpSender {


### PR DESCRIPTION
- Bumped version
- Reordered imports in `HttpSender.java` due to checkstyle violations
- Added functionality to replace a UNIX timestamp placeholder `${unix-timestamp}` with the current system timestamp.
- Refactoring due to checkstyle violations